### PR TITLE
Feature/hocs 2907 compose up all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/docker/keycloak/hsperfdata_jboss/*
+/docker/keycloak/hsperfdata_jboss
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.env
-.idea
+/docker/keycloak/hsperfdata_jboss/*

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,12 +85,17 @@ CASEWORK_TAG=branch-epic_HOCS-COMP
 WORKFLOW_TAG=branch-epic_HOCS-COMP
 CASE_CREATOR_TAG=branch-epic_HOCS-COMP
 INFO_TAG=branch-epic_HOCS-COMP
-HOCS_DATA_TAG=branch-epic_HOCS-COMP
+HOCS_DATA_TAG=branch-feature_HOCS-2907-compose-up-all
+HOCS_DATA_REPO=hocs-data
+HOCS_DATA_ELASTIC_REPO=hocs-data-elastic
 ```
-The syntax of a tag for a feature branch looks like this:
-```shell
-HOCS_DATA_ELASTIC_TAG=branch-feature_HOCS-2907-compose-up-all
-```
+The `HOCS_DATA_REPO` can be one of :
+* hocs-data
+* hocs-data-wcs
+
+The `HOCS_DATA_ELASTIC_REPO` can be one of :
+* hocs-data-elastic
+* hocs-data-wcs-elastic
 
 ## Data migration
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ This directory contains configuration for Docker Compose, a quick way to get a
 local HOCS environment on your computer. 
 
 If this is the first time you run it, Compose will download the latest images; this could
-take fifteen minutes, depending on your connection. To relieve pressure on your machines resources, 
+take fifteen minutes, depending on your connection. To relieve pressure on your machine&rsquo;s resources, 
 it is better to pull the images first then run up the app 
 
 To pull all services, do:
@@ -78,7 +78,7 @@ $ docker-compose up
 
 ## Use of .env file
 The docker-compose file has variables for the image tags. This allows the use of a ``.env`` file.
-By default, ``branch-main`` will be used. The following is an example of a file overriding some services:
+By default, ``latest`` will be used. The following is an example of a file overriding some services:
 ```shell
 FRONTEND_TAG=branch-epic_HOCS-COMP
 CASEWORK_TAG=branch-epic_HOCS-COMP
@@ -116,7 +116,7 @@ $ $(aws ecr get-login --no-include-email --profile acp-ecr)
 To be able to pull the image you need to be in authorised to do so.
 This is in the ACP Hub in the Docker repos section.
 
-The AWS credentials are stored in the hub, under your "Connected Identities" section.
+AWS credentials are stored in the ACP hub, under your &ldquo;Connected Identities&rdquo; section.
 
 ## Manual data import
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,14 +3,21 @@
 This directory contains configuration for Docker Compose, a quick way to get a
 local HOCS environment on your computer. 
 
+If this is the first time you run it, Compose will download the latest images; this could
+take fifteen minutes, depending on your connection. To relieve pressure on your machines resources, 
+it is better to pull the images first then run up the app 
+
+To pull all services, do:
+```console
+$ docker-compose pull
+```
+
 To start all services, do:
 ```console
 $ docker-compose up
 ```
 
-This might take over five minutes to run.
-The first time you run it Compose will download the latest images; this could
-take an additional fifteen minutes, depending on your connection.
+With Docker using 8GB of memory, this takes approximately 4 minutes to startup.
 
 You can also ask Compose to background the process (detach) once everything is
 up and running:
@@ -23,6 +30,7 @@ To turn the containers off, press CTRL and C at the same time in that terminal
 ```console
 $ docker-compose stop
 ```
+> Note this will retain data in the local database.
 
 If you wish to Stop and remove containers, networks, images, and volumes, run the following:
 ```console
@@ -78,6 +86,10 @@ WORKFLOW_TAG=branch-epic_HOCS-COMP
 CASE_CREATOR_TAG=branch-epic_HOCS-COMP
 INFO_TAG=branch-epic_HOCS-COMP
 HOCS_DATA_TAG=branch-epic_HOCS-COMP
+```
+The syntax of a tag for a feature branch looks like this:
+```shell
+HOCS_DATA_ELASTIC_TAG=branch-feature_HOCS-2907-compose-up-all
 ```
 
 ## Data migration
@@ -187,7 +199,7 @@ headers yourself using (for example) a browser extension. Ask an existing
 developer for their copy. This might manifest itself as a browser timeout:
 check stderr before assuming something else is wrong.
 
-### Search index
+### Manually applying the Search indexes
 
 The search service needs elastic indexes applying. Without them, you will see continuous search errors.
 The search indexes are contained in either hocs-data or hocs-data-wcs. To apply the index, do th following:

--- a/docker/README.md
+++ b/docker/README.md
@@ -78,7 +78,7 @@ $ docker-compose up
 
 ## Use of .env file
 The docker-compose file has variables for the image tags. This allows the use of a ``.env`` file.
-By default, ``branch-main`` will be used. The following is an example of a file overriding some services :
+By default, ``branch-main`` will be used. The following is an example of a file overriding some services:
 ```shell
 FRONTEND_TAG=branch-epic_HOCS-COMP
 CASEWORK_TAG=branch-epic_HOCS-COMP
@@ -89,21 +89,21 @@ HOCS_DATA_TAG=branch-feature_HOCS-2907-compose-up-all
 HOCS_DATA_REPO=hocs-data
 HOCS_DATA_ELASTIC_REPO=hocs-data-elastic
 ```
-The `HOCS_DATA_REPO` can be one of :
+The `HOCS_DATA_REPO` can be one of:
 * hocs-data
 * hocs-data-wcs
 
-The `HOCS_DATA_ELASTIC_REPO` can be one of :
+The `HOCS_DATA_ELASTIC_REPO` can be one of:
 * hocs-data-elastic
 * hocs-data-wcs-elastic
 
 ## Data migration
 
-The info-service doesn&rsquo;t come with its schema, it relies on a data_migration step in the docker-compose file.
+The info-service doesn&rsquo;t come with its schema. To load the schema it relies on a data_migration step in the docker-compose file.
 
 The data_migration step loads the info schema using flyway scripts.
 
-To select hocs-data pr hocs-data-wcs set the variable ``HOCS_DATA_REPO`` in your ``.env`` file to either :
+To select hocs-data or hocs-data-wcs set the variable ``HOCS_DATA_REPO`` in your ``.env`` file to either:
 * hocs-data (default)
 * hocs-data-wcs
 
@@ -207,7 +207,7 @@ check stderr before assuming something else is wrong.
 ### Manually applying the Search indexes
 
 The search service needs elastic indexes applying. Without them, you will see continuous search errors.
-The search indexes are contained in either hocs-data or hocs-data-wcs. To apply the index, do th following:
+The search indexes are contained in either hocs-data or hocs-data-wcs. To apply the index, do the following:
 ```console
 $ git clone git@github.com:UKHomeOffice/hocs-data.git
 $ cd hocs-data

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # docker-compose
 
 This directory contains configuration for Docker Compose, a quick way to get a
-local HOCS environment on your computer.
+local HOCS environment on your computer. 
 
 To start all services, do:
 ```console
@@ -12,9 +12,6 @@ This might take over five minutes to run.
 The first time you run it Compose will download the latest images; this could
 take an additional fifteen minutes, depending on your connection.
 
-You&rsquo;ll also need to configure the database schema;
-[see below for details](#missing-sql-tables).
-
 You can also ask Compose to background the process (detach) once everything is
 up and running:
 ```console
@@ -24,8 +21,14 @@ $ docker-compose up -d
 To turn the containers off, press CTRL and C at the same time in that terminal
 (SIGINT). Alternatively, run:
 ```console
+$ docker-compose stop
+```
+
+If you wish to Stop and remove containers, networks, images, and volumes, run the following:
+```console
 $ docker-compose down
 ```
+> Note this will remove the local database and all its data.
 
 This will tear down the environment, so you&rsquo;ll have a lengthy wait when
 starting the containers next time. If you&rsquo;re going to need the environment
@@ -65,6 +68,69 @@ $ docker-compose pull
 $ docker-compose up
 ```
 
+## Use of .env file
+The docker-compose file has variables for the image tags. This allows the use of a ``.env`` file.
+By default, ``branch-main`` will be used. The following is an example of a file overriding some services :
+```shell
+FRONTEND_TAG=branch-epic_HOCS-COMP
+CASEWORK_TAG=branch-epic_HOCS-COMP
+WORKFLOW_TAG=branch-epic_HOCS-COMP
+CASE_CREATOR_TAG=branch-epic_HOCS-COMP
+INFO_TAG=branch-epic_HOCS-COMP
+HOCS_DATA_TAG=branch-epic_HOCS-COMP
+```
+
+## Data migration
+
+The info-service doesn&rsquo;t come with its schema, it relies on a data_migration step in the docker-compose file.
+
+The data_migration step loads the info schema using flyway scripts.
+
+To select hocs-data pr hocs-data-wcs set the variable ``HOCS_DATA_REPO`` in your ``.env`` file to either :
+* hocs-data (default)
+* hocs-data-wcs
+
+The docker image for the data is stored in AWS ECR, to pull it you will need to set up
+an AWS profile and then run the following:
+```console
+$ $(aws ecr get-login --no-include-email --profile acp-ecr)
+```
+
+To be able to pull the image you need to be in authorised to do so.
+This is in the ACP Hub in the Docker repos section.
+
+The AWS credentials are stored in the hub, under your "Connected Identities" section.
+
+## Manual data import
+
+The info-service schema isn&rsquo;t currently available publicly, and is stored
+in a private repository on GitHub. Request access from an existing team member.
+If you&rsquo;re working in Government but aren&rsquo;t a member of the DECS
+development team, ask someone from the Home Office in the cross-Government Slack
+channel to ask us on your behalf.
+
+Depending on which version of HOCS you wish to run, clone the repository and
+run the Docker Compose included in that repo:
+
+```console
+$ git clone git@github.com:UKHomeOffice/hocs-data.git
+$ cd hocs-data
+$ docker-compose up
+```
+
+```console
+$ git clone git@github.com:UKHomeOffice/hocs-data-wcs.git
+$ cd hocs-data-wcs
+$ docker-compose up
+```
+
+You need to do this after the PostgreSQL server is ready, but before the
+info-service pod is running. When you `docker-compose up` for the first time,
+there&rsquo;s usually a short delay immediately after, when Localstack is
+getting ready. That&rsquo;s the best time to `cd` into the schema and run these
+commands.
+
+
 ## Troubleshooting
 ### Unhealthy containers
 
@@ -75,7 +141,7 @@ for use.
 If a container doesn't start working after a certain period of time, it will be
 marked as &ldquo;unhealthy&rdquo; and Docker Compose will exit.
 
-The error mesage will look something like this:
+The error message will look something like this:
 
 ```console
 ERROR: for frontend  Container "fe34db64b428" is unhealthy.
@@ -113,40 +179,6 @@ $ docker-compose up
 For more serious problems you might need to tear down the environment with
 `docker-compose down` and start again.
 
-### Missing SQL tables
-
-The info-service doesn&rsquo;t come with its schema, so if your PostgreSQL
-container is new, like when yoursquo;re setting up your environment for the
-first time, your info-service will complain about missing data;
-you&rsquo;ll need to set the schema up manually.
-
-The info-service schema isn&rsquo;t currently available publicly, and is stored
-in a private repository on GitHub. Request access from an existing team member.
-If you&rsquo;re working in Government but aren&rsquo;t a member of the DECS
-development team, ask someone from the Home Office in the cross-Government Slack
-channel to ask us on your behalf.
-
-Depending on which version of HOCS you wish to run, clone the repository and
-run the Docker Compose included in that repo:
-
-```console
-$ git clone git@github.com:UKHomeOffice/hocs-data.git
-$ cd hocs-data
-$ docker-compose up
-```
-
-```console
-$ git clone git@github.com:UKHomeOffice/hocs-data-wcs.git
-$ cd hocs-data-wcs
-$ docker-compose up
-```
-
-You need to do this after the PostgreSQL server is ready, but before the
-info-service pod is running. When you `docker-compose up` for the first time,
-there&rsquo;s usually a short delay immediately after, when Localstack is
-getting ready. That&rsquo;s the best time to `cd` into the schema and run these
-commands.
-
 ### 403 on Frontend
 
 The frontend container doesn&rsquo;t handle authentication, as it is handled
@@ -154,3 +186,13 @@ by a proxy before it hits the app. You&rsquo;ll need to set authentication
 headers yourself using (for example) a browser extension. Ask an existing
 developer for their copy. This might manifest itself as a browser timeout:
 check stderr before assuming something else is wrong.
+
+### Search index
+
+The search service needs elastic indexes applying. Without them, you will see continuous search errors.
+The search indexes are contained in either hocs-data or hocs-data-wcs. To apply the index, do th following:
+```console
+$ git clone git@github.com:UKHomeOffice/hocs-data.git
+$ cd hocs-data
+$ curl -X PUT http://127.0.0.1:4571/local-case -H "Content-Type: application/json" -d @ElasticSearch/elastic_mapping
+```

--- a/docker/clamav_mock/mockserver.json
+++ b/docker/clamav_mock/mockserver.json
@@ -1,0 +1,10 @@
+[
+  {
+    "httpRequest": {
+      "path": "/scan"
+    },
+    "httpResponse": {
+      "body": "Everything ok : true"
+    }
+  }
+]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -112,7 +112,7 @@ services:
         condition: service_healthy
 
   load_elastic:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-hocs-data-elastic}:${HOCS_DATA_TAG:-branch-main}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-hocs-data-elastic}:${HOCS_DATA_TAG:-}
     environment:
       ELASTIC_HOST: localstack
     networks:
@@ -122,7 +122,7 @@ services:
         condition: service_healthy
     
   data_migration:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-branch-main}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-}
     environment:
       FLYWAY_URL: jdbc:postgresql://postgres:5432/postgres
       FLYWAY_USER: root
@@ -136,7 +136,7 @@ services:
   frontend:
     # health check has been removed because we have no way of testing in docker-compose
     # to perform a health check we would need to add curl or something similar to the container.
-    image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-}
     ports:
       - 8080:8080
     networks:
@@ -170,7 +170,7 @@ services:
       start_period: 2m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG:-}
     ports:
       - 8082:8080
     networks:
@@ -197,7 +197,7 @@ services:
       start_period: 3m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-}
     ports:
       - 8091:8080
     networks:
@@ -227,7 +227,7 @@ services:
       start_period: 2m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG:-}
     ports:
       - 8087:8080
     networks:
@@ -252,7 +252,7 @@ services:
       start_period: 1m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG:-}
     ports:
       - 8088:8080
     networks:
@@ -285,7 +285,7 @@ services:
       start_period: 3m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG:-}
     ports:
       - 8085:8080
     networks:
@@ -315,7 +315,7 @@ services:
   converter:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-    image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-}
     ports:
       - 8084:8080
     networks:
@@ -329,7 +329,7 @@ services:
       start_period: 2m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG:-}
     ports:
       - 8083:8080
     networks:
@@ -364,7 +364,7 @@ services:
       start_period: 1m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG:-}
     ports:
       - 8090:8080
     networks:
@@ -376,7 +376,7 @@ services:
       HOCS_SEARCH_SERVICE: 'http://documents:8080'
 
   case_creator:
-    image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-branch-main}
+    image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-}
     ports:
       - 8092:8080
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '2.4' # v3 doesn't support depends_on condition
 
 services:
 
@@ -188,8 +188,6 @@ services:
       timeout: 30s
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-branch-main}
-    mem_limit: 2G
-    mem_reservation: 1536M
     ports:
       - 8091:8080
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -112,7 +112,7 @@ services:
         condition: service_healthy
 
   load_elastic:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-hocs-data-elastic}:${HOCS_DATA_TAG:-}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-latesthocs-data-elastic}:${HOCS_DATA_TAG:-latest}
     environment:
       ELASTIC_HOST: localstack
     networks:
@@ -122,7 +122,7 @@ services:
         condition: service_healthy
     
   data_migration:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-latesthocs-data}:${HOCS_DATA_TAG:-latest}
     environment:
       FLYWAY_URL: jdbc:postgresql://postgres:5432/postgres
       FLYWAY_USER: root
@@ -136,7 +136,7 @@ services:
   frontend:
     # health check has been removed because we have no way of testing in docker-compose
     # to perform a health check we would need to add curl or something similar to the container.
-    image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-latest}
     ports:
       - 8080:8080
     networks:
@@ -170,7 +170,7 @@ services:
       start_period: 2m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG:-latest}
     ports:
       - 8082:8080
     networks:
@@ -197,7 +197,7 @@ services:
       start_period: 3m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-latest}
     ports:
       - 8091:8080
     networks:
@@ -227,7 +227,7 @@ services:
       start_period: 2m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG:-latest}
     ports:
       - 8087:8080
     networks:
@@ -252,7 +252,7 @@ services:
       start_period: 1m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG:-latest}
     ports:
       - 8088:8080
     networks:
@@ -285,7 +285,7 @@ services:
       start_period: 3m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG:-latest}
     ports:
       - 8085:8080
     networks:
@@ -315,7 +315,7 @@ services:
   converter:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-    image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-latest}
     ports:
       - 8084:8080
     networks:
@@ -329,7 +329,7 @@ services:
       start_period: 2m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG:-latest}
     ports:
       - 8083:8080
     networks:
@@ -364,7 +364,7 @@ services:
       start_period: 1m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG:-latest}
     ports:
       - 8090:8080
     networks:
@@ -376,7 +376,7 @@ services:
       HOCS_SEARCH_SERVICE: 'http://documents:8080'
 
   case_creator:
-    image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-}
+    image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-latest}
     ports:
       - 8092:8080
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -134,8 +134,11 @@ services:
         condition: service_healthy
 
   frontend:
-    # health check has been removed because we have no way of testing in docker-compose
-    # to perform a health check we would need to add curl or something similar to the container.
+    healthcheck:
+      test: [ "CMD", "wget", "-qo", "/dev/null",  "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-latest}
     ports:
       - 8080:8080

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.4' # v3 doesn't support depends_on condition
+version: '3.4'
 
 services:
 
@@ -19,34 +19,24 @@ services:
     tmpfs:
       - /var/lib/postgresql
 
-  clamd:
-    healthcheck:
-      test: [ "CMD", "./check.sh" ]
-      start_period: 2m
-    image: mkodockx/docker-clamav:buster-slim
-    ports:
-      - "3310:3310/tcp"
-    networks:
-      - hocs-network
-
   clamav:
-    healthcheck:
-      # -f makes curl exit with 22 on error (it doesn't normally)
-      test: [ "CMD", "curl", "-f", "http://localhost:8080" ]
-    image: lokori/clamav-rest
-    environment:
-      - CLAMD_HOST=clamd
+    # Use a mockserver instead of bloated clamav 
+    image: mockserver/mockserver:mockserver-5.11.1
+    command: -logLevel INFO -serverPort 8080
     ports:
       - 8086:8080
     networks:
       - hocs-network
-    depends_on:
-      clamd:
-        condition: service_healthy
-
+    environment:
+      MOCKSERVER_PROPERTY_FILE: /config/mockserver.json
+      MOCKSERVER_INITIALIZATION_JSON_PATH: /config/mockserver.json
+    volumes:
+      - ${PWD}/clamav_mock:/config
+        
   keycloak:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/auth" ]
+      start_period: 1m
     image: jboss/keycloak:5.0.0
     restart: always
     ports:
@@ -64,16 +54,10 @@ services:
 
   localstack:
     healthcheck:
-      test:
-        - CMD
-        - bash
-        - -c
-        - awslocal es list-domain-names
-          && awslocal s3 ls
-          && awslocal sqs list-queues
-      interval: 5s
-      timeout: 10s
-      start_period: 90s
+      test: "bash -c 'AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake aws --endpoint-url=http://localhost:4572 s3 ls'"
+      start_period: 1m
+      timeout: 30s
+      retries: 3
     image: localstack/localstack:0.9.5
     ports:
       - 9000:8080
@@ -87,7 +71,7 @@ services:
     environment:
       HOSTNAME_EXTERNAL: localstack
       DEFAULT_REGION: eu-west-2
-      SERVICES: sqs,s3,sns,es
+      SERVICES: sqs,sns,es,s3
 
   aws_cli:
     image: xueshanf/awscli
@@ -127,9 +111,21 @@ services:
       localstack:
         condition: service_healthy
 
+  data_migration:
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-branch-main}
+    environment:
+      FLYWAY_URL: jdbc:postgresql://postgres:5432/postgres
+      FLYWAY_USER: root
+      FLYWAY_PASSWORD: dev
+    networks:
+      - hocs-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   frontend:
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+    # health check has been removed because we have no way of testing in docker-compose
+    # to perform a health check we would need to add curl or something similar to the container.
     image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-branch-main}
     ports:
       - 8080:8080
@@ -161,7 +157,9 @@ services:
   casework:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      start_period: 240s
+      start_period: 2m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG:-branch-main}
     ports:
       - 8082:8080
@@ -186,13 +184,18 @@ services:
   workflow:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      start_period: 240s
+      start_period: 3m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-branch-main}
+    mem_limit: 2G
+    mem_reservation: 1.5G
     ports:
       - 8091:8080
     networks:
       - hocs-network
     environment:
+      JAVA_OPTS: '-Xms1.5G -Xmx2G'
       SPRING_PROFILES_ACTIVE: 'development, local'
       SERVER_PORT: 8080
       CASE_QUEUE_NAME: 'case-queue'
@@ -209,21 +212,13 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      localstack:
-        condition: service_healthy # this waits until healthcheck passes
-      aws_cli:
-        condition: service_started # this doesn't
-      casework:
-        condition: service_healthy
-      documents:
-        condition: service_healthy
-      info:
-        condition: service_healthy
 
   audit:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      start_period: 60s
+      start_period: 2m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG:-branch-main}
     ports:
       - 8087:8080
@@ -246,7 +241,9 @@ services:
   search:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      start_period: 180s
+      start_period: 1m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG:-branch-main}
     ports:
       - 8088:8080
@@ -277,6 +274,9 @@ services:
   info:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      start_period: 3m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG:-branch-main}
     ports:
       - 8085:8080
@@ -297,12 +297,13 @@ services:
       AUDIT_QUEUE_DLQ_NAME: 'audit-queue-dlq'
       HOCS_AUDIT_SERVICE: 'http://audit:8080'
     depends_on:
-      postgres:
-        condition: service_healthy
-      localstack:
-        condition: service_healthy
       aws_cli:
         condition: service_started
+      data_migration:
+        condition: service_started
+      keycloak:
+        condition: service_started
+  
   converter:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
@@ -317,7 +318,9 @@ services:
   documents:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      start_period: 90s
+      start_period: 2m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG:-branch-main}
     ports:
       - 8083:8080
@@ -338,8 +341,6 @@ services:
       DB_HOST: 'postgres'
       AWS_LOCAL_HOST: 'localstack'
     depends_on:
-      clamav:
-        condition: service_healthy
       postgres:
         condition: service_healthy
       localstack:
@@ -352,6 +353,9 @@ services:
   templates:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      start_period: 1m
+      timeout: 30s
+      retries: 3
     image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG:-branch-main}
     ports:
       - 8090:8080
@@ -362,18 +366,8 @@ services:
       HOCS_INFO_SERVICE: 'http://info:8080'
       HOCS_AUDITSERVICE: 'http://casework:8080'
       HOCS_SEARCH_SERVICE: 'http://documents:8080'
-    depends_on:
-      info:
-        condition: service_healthy
-      audit:
-        condition: service_healthy
-      documents:
-        condition: service_healthy
 
   case_creator:
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      start_period: 90s
     image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-branch-main}
     ports:
       - 8092:8080
@@ -389,7 +383,7 @@ services:
       CASE_CREATOR_CASE_SERVICE: http://casework:8080
       CASE_CREATOR_BASICAUTH: 'UNSET'
       CASE_CREATOR_UKVI_COMPLAINT_USER: '04167856-f772-4bca-87b9-f8b6739853b7'
-      CASE_CREATOR_UKVI_COMPLAINT_GROUP: '/CMS_CCH_zqxmzQ6iGEkTRw'
+      CASE_CREATOR_UKVI_COMPLAINT_GROUP: '/CMS_REG_bdhvyvn6fnskcg'
       CASE_CREATOR_SQS_ACCESS_KEY: '1234'
       CASE_CREATOR_SQS_SECRET_KEY: '1234'
       CASE_CREATOR_UKVI_COMPLAINT_QUEUE_NAME: 'ukvi-complaint-queue'
@@ -401,8 +395,6 @@ services:
       DOCUMENT_S3_SECRET_KEY: '1234'
       DOCUMENT_S3_UNTRUSTED_BUCKET_NAME: 'untrusted-bucket'
     depends_on:
-      localstack:
-        condition: service_healthy
       aws_cli:
         condition: service_started
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -111,6 +111,16 @@ services:
       localstack:
         condition: service_healthy
 
+  load_elastic:
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic:${HOCS_DATA_ELASTIC_TAG:-branch-main}
+    environment:
+      ELASTIC_HOST: localstack
+    networks:
+      - hocs-network
+    depends_on:
+      localstack:
+        condition: service_healthy
+    
   data_migration:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-branch-main}
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -112,7 +112,7 @@ services:
         condition: service_healthy
 
   load_elastic:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic:${HOCS_DATA_ELASTIC_TAG:-branch-main}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-hocs-data-elastic}:${HOCS_DATA_TAG:-branch-main}
     environment:
       ELASTIC_HOST: localstack
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -189,13 +189,13 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-branch-main}
     mem_limit: 2G
-    mem_reservation: 1.5G
+    mem_reservation: 1536M
     ports:
       - 8091:8080
     networks:
       - hocs-network
     environment:
-      JAVA_OPTS: '-Xms1.5G -Xmx2G'
+      JAVA_OPTS: '-Xms1536M -Xmx2G'
       SPRING_PROFILES_ACTIVE: 'development, local'
       SERVER_PORT: 8080
       CASE_QUEUE_NAME: 'case-queue'
@@ -383,7 +383,7 @@ services:
       CASE_CREATOR_CASE_SERVICE: http://casework:8080
       CASE_CREATOR_BASICAUTH: 'UNSET'
       CASE_CREATOR_UKVI_COMPLAINT_USER: '04167856-f772-4bca-87b9-f8b6739853b7'
-      CASE_CREATOR_UKVI_COMPLAINT_GROUP: '/CMS_REG_bdhvyvn6fnskcg'
+      CASE_CREATOR_UKVI_COMPLAINT_GROUP: '/COMP_REG_bdhvyvn6fskcg'
       CASE_CREATOR_SQS_ACCESS_KEY: '1234'
       CASE_CREATOR_SQS_SECRET_KEY: '1234'
       CASE_CREATOR_UKVI_COMPLAINT_QUEUE_NAME: 'ukvi-complaint-queue'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -112,7 +112,7 @@ services:
         condition: service_healthy
 
   load_elastic:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-latesthocs-data-elastic}:${HOCS_DATA_TAG:-latest}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_ELASTIC_REPO:-hocs-data-elastic}:${HOCS_DATA_TAG:-latest}
     environment:
       ELASTIC_HOST: localstack
     networks:
@@ -122,7 +122,7 @@ services:
         condition: service_healthy
     
   data_migration:
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-latesthocs-data}:${HOCS_DATA_TAG:-latest}
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-latest}
     environment:
       FLYWAY_URL: jdbc:postgresql://postgres:5432/postgres
       FLYWAY_USER: root


### PR DESCRIPTION
Improvements to allow 'docker-compose up' to work.

- Cleanup health checks
- Adjust health check timeouts
- Add memory options for workflow (can use 1.3G memory!)
- Use a mock server instead of clamav (saves 1.2G memory)
- Add a data migrate step lo load the hocs-data into the info schema
- Add a load elastic step to add the elastic indexes.
- Tested with 8G memory of Docker resource

All noted in the docker/README