### PR TITLE
HOCS-3205: Add Management UI to docker compose 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '2.4' # v3 doesn't support depends_on condition
+version: "2.4" # v3 doesn't support depends_on condition
 
 services:
-
   postgres:
     image: postgres:9.6
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U root" ]
+      test: ["CMD-SHELL", "pg_isready -U root"]
     restart: always
     ports:
       - 5432:5432
@@ -20,7 +19,7 @@ services:
       - /var/lib/postgresql
 
   clamav:
-    # Use a mockserver instead of bloated clamav 
+    # Use a mockserver instead of bloated clamav
     image: mockserver/mockserver:mockserver-5.11.1
     command: -logLevel INFO -serverPort 8080
     ports:
@@ -32,10 +31,10 @@ services:
       MOCKSERVER_INITIALIZATION_JSON_PATH: /config/mockserver.json
     volumes:
       - ${PWD}/clamav_mock:/config
-        
+
   keycloak:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
       start_period: 1m
     image: jboss/keycloak:5.0.0
     restart: always
@@ -108,7 +107,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: UNSET
       AWS_SECRET_ACCESS_KEY: UNSET
-      AWS_DEFAULT_REGION: 'eu-west-2'
+      AWS_DEFAULT_REGION: "eu-west-2"
     networks:
       - hocs-network
     depends_on:
@@ -124,7 +123,7 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
-    
+
   data_migration:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/${HOCS_DATA_REPO:-hocs-data}:${HOCS_DATA_TAG:-latest}
     environment:
@@ -139,7 +138,7 @@ services:
 
   refresh_members:
     image: curlimages/curl:7.76.1
-    command: [ "http://info:8080/admin/member/refresh" ]
+    command: ["http://info:8080/admin/member/refresh"]
     networks:
       - hocs-network
     depends_on:
@@ -148,7 +147,7 @@ services:
 
   frontend:
     healthcheck:
-      test: [ "CMD", "wget", "-qo", "/dev/null",  "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-qo", "/dev/null", "http://localhost:8080/health"]
       interval: 10s
       timeout: 10s
       retries: 3
@@ -158,7 +157,7 @@ services:
     networks:
       - hocs-network
     environment:
-      USE_CLIENTSIDE: 'true'
+      USE_CLIENTSIDE: "true"
       WORKFLOW_SERVICE: http://workflow:8080
       CASEWORK_SERVICE: http://casework:8080
       INFO_SERVICE: http://info:8080
@@ -166,7 +165,7 @@ services:
       ALLOWED_FILE_EXTENSIONS: 'txt,doc,docx'
       DOCUMENT_BULK_LIMIT: 40
       VALID_DAYS_RANGE: 180
-      S3_BUCKET: 'untrusted-bucket'
+      S3_BUCKET: "untrusted-bucket"
       S3_ENDPOINT: http://localstack:4572
     depends_on:
       workflow:
@@ -182,7 +181,7 @@ services:
 
   casework:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 2m
       timeout: 30s
       retries: 3
@@ -192,14 +191,14 @@ services:
     networks:
       - hocs-network
     environment:
-      SPRING_PROFILES_ACTIVE: 'development, local'
+      SPRING_PROFILES_ACTIVE: "development, local"
       SERVER_PORT: 8080
-      DB_HOST: 'postgres'
-      AWS_LOCAL_HOST: 'localstack'
-      HOCS_INFO_SERVICE: 'http://info:8080'
-      HOCS_AUDITSERVICE: 'http://audit:8080'
-      HOCS_SEARCH_SERVICE: 'http://search:8080'
-      HOCS_DOCUMENT_SERVICE: 'http://documents:8080'
+      DB_HOST: "postgres"
+      AWS_LOCAL_HOST: "localstack"
+      HOCS_INFO_SERVICE: "http://info:8080"
+      HOCS_AUDITSERVICE: "http://audit:8080"
+      HOCS_SEARCH_SERVICE: "http://search:8080"
+      HOCS_DOCUMENT_SERVICE: "http://documents:8080"
       AUDIT_TOPIC_NAME: "hocs-audit-topic"
     depends_on:
       postgres:
@@ -209,7 +208,7 @@ services:
 
   workflow:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 3m
       timeout: 30s
       retries: 3
@@ -219,27 +218,27 @@ services:
     networks:
       - hocs-network
     environment:
-      JAVA_OPTS: '-Xms1536M -Xmx2G'
-      SPRING_PROFILES_ACTIVE: 'development, local'
+      JAVA_OPTS: "-Xms1536M -Xmx2G"
+      SPRING_PROFILES_ACTIVE: "development, local"
       SERVER_PORT: 8080
-      CASE_QUEUE_NAME: 'case-queue'
-      CASE_QUEUE_DLQ_NAME: 'case-queue-dlq'
-      DOCS_QUEUE_NAME: 'document-queue'
-      DOCS_QUEUE_DLQ_NAME: 'document-queue-dlq'
-      HOCS_URL: 'http://localhost:8080'
-      HOCS_CASE_SERVICE: 'http://casework:8080'
-      HOCS_DOCUMENT_SERVICE: 'http://documents:8080'
-      HOCS_INFO_SERVICE: 'http://info:8080'
-      DB_HOST: 'postgres'
-      DB_SCHEMA_NAME: 'workflow'
-      AWS_LOCAL_HOST: 'localstack'
+      CASE_QUEUE_NAME: "case-queue"
+      CASE_QUEUE_DLQ_NAME: "case-queue-dlq"
+      DOCS_QUEUE_NAME: "document-queue"
+      DOCS_QUEUE_DLQ_NAME: "document-queue-dlq"
+      HOCS_URL: "http://localhost:8080"
+      HOCS_CASE_SERVICE: "http://casework:8080"
+      HOCS_DOCUMENT_SERVICE: "http://documents:8080"
+      HOCS_INFO_SERVICE: "http://info:8080"
+      DB_HOST: "postgres"
+      DB_SCHEMA_NAME: "workflow"
+      AWS_LOCAL_HOST: "localstack"
     depends_on:
       postgres:
         condition: service_healthy
 
   audit:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 2m
       timeout: 30s
       retries: 3
@@ -249,13 +248,13 @@ services:
     networks:
       - hocs-network
     environment:
-      SPRING_PROFILES_ACTIVE: 'development, local'
+      SPRING_PROFILES_ACTIVE: "development, local"
       SERVER_PORT: 8080
-      DB_HOST: 'postgres'
-      AUDIT_QUEUE_NAME: 'audit-queue'
-      AUDIT_QUEUE_DLQ_NAME: 'audit-queue-dlq'
-      HOCS_INFO_SERVICE: 'http://info:8080'
-      AWS_LOCAL_HOST: 'localstack'
+      DB_HOST: "postgres"
+      AUDIT_QUEUE_NAME: "audit-queue"
+      AUDIT_QUEUE_DLQ_NAME: "audit-queue-dlq"
+      HOCS_INFO_SERVICE: "http://info:8080"
+      AWS_LOCAL_HOST: "localstack"
     depends_on:
       postgres:
         condition: service_healthy
@@ -264,7 +263,7 @@ services:
 
   search:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 1m
       timeout: 30s
       retries: 3
@@ -274,19 +273,19 @@ services:
     networks:
       - hocs-network
     environment:
-      SPRING_PROFILES_ACTIVE: 'development, local, localelastic'
+      SPRING_PROFILES_ACTIVE: "development, local, localelastic"
       SERVER_PORT: 8080
-      DB_HOST: 'postgres'
-      SEARCH_QUEUE_NAME: 'search-queue'
-      SEARCH_QUEUE_DLQ_NAME: 'search-queue-dlq'
-      AWS_LOCAL_HOST: 'localstack'
-      ELASTIC_INDEX_PREFIX: 'local'
-      ELASTICSEARCH_HOST: 'localstack'
-      ELASTICSEARCH_PORT: '4571'
-      ELASTICSEARCH_ACCESS_KEY: 'UNSET'
-      ELASTICSEARCH_SECRET_KEY: 'UNSET'
-      AWS_SQS_ACCESS_KEY: 'UNSET'
-      AWS_SQS_SECRET_KEY: 'UNSET'
+      DB_HOST: "postgres"
+      SEARCH_QUEUE_NAME: "search-queue"
+      SEARCH_QUEUE_DLQ_NAME: "search-queue-dlq"
+      AWS_LOCAL_HOST: "localstack"
+      ELASTIC_INDEX_PREFIX: "local"
+      ELASTICSEARCH_HOST: "localstack"
+      ELASTICSEARCH_PORT: "4571"
+      ELASTICSEARCH_ACCESS_KEY: "UNSET"
+      ELASTICSEARCH_SECRET_KEY: "UNSET"
+      AWS_SQS_ACCESS_KEY: "UNSET"
+      AWS_SQS_SECRET_KEY: "UNSET"
     depends_on:
       postgres:
         condition: service_healthy
@@ -297,7 +296,7 @@ services:
 
   info:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 3m
       timeout: 30s
       retries: 3
@@ -307,19 +306,19 @@ services:
     networks:
       - hocs-network
     environment:
-      SPRING_PROFILES_ACTIVE: 'development, local'
+      SPRING_PROFILES_ACTIVE: "development, local"
       SERVER_PORT: 8080
-      DB_HOST: 'postgres'
-      CASE_QUEUE_NAME: 'case-queue'
-      CASE_QUEUE_DLQ_NAME: 'case-queue-dlq'
-      DOCS_QUEUE_NAME: 'document-queue'
-      DOCS_QUEUE_DLQ_NAME: 'document-queue-dlq'
-      HOCS_CASE_SERVICE: 'http://casework:8080'
-      HOCS_DOCUMENT_SERVICE: 'http://documents:8080'
-      KEYCLOAK_SERVER_ROOT: 'http://keycloak:8080'
-      AUDIT_QUEUE_NAME: 'audit-queue'
-      AUDIT_QUEUE_DLQ_NAME: 'audit-queue-dlq'
-      HOCS_AUDIT_SERVICE: 'http://audit:8080'
+      DB_HOST: "postgres"
+      CASE_QUEUE_NAME: "case-queue"
+      CASE_QUEUE_DLQ_NAME: "case-queue-dlq"
+      DOCS_QUEUE_NAME: "document-queue"
+      DOCS_QUEUE_DLQ_NAME: "document-queue-dlq"
+      HOCS_CASE_SERVICE: "http://casework:8080"
+      HOCS_DOCUMENT_SERVICE: "http://documents:8080"
+      KEYCLOAK_SERVER_ROOT: "http://keycloak:8080"
+      AUDIT_QUEUE_NAME: "audit-queue"
+      AUDIT_QUEUE_DLQ_NAME: "audit-queue-dlq"
+      HOCS_AUDIT_SERVICE: "http://audit:8080"
     depends_on:
       aws_cli:
         condition: service_started
@@ -327,10 +326,10 @@ services:
         condition: service_started
       keycloak:
         condition: service_started
-  
+
   converter:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-latest}
     ports:
       - 8084:8080
@@ -341,7 +340,7 @@ services:
 
   documents:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 2m
       timeout: 30s
       retries: 3
@@ -351,19 +350,19 @@ services:
     networks:
       - hocs-network
     environment:
-      SPRING_PROFILES_ACTIVE: 'development, local, postgres'
-      SPRING_FLYWAY_SCHEMAS: 'document'
+      SPRING_PROFILES_ACTIVE: "development, local, postgres"
+      SPRING_FLYWAY_SCHEMAS: "document"
       SERVER_PORT: 8080
-      DOCS_QUEUE_NAME: 'document-queue'
-      DOCS_QUEUE_DLQ_NAME: 'document-queue-dlq'
-      CASE_QUEUE_NAME: 'case-queue'
-      CASE_QUEUE_DLQ_NAME: 'case-queue-dlq'
-      DOCS_TRUSTEDS3BUCKETNAME: 'trusted-bucket'
-      DOCS_UNTRUSTEDS3BUCKETNAME: 'untrusted-bucket'
-      HOCSCONVERTER_ROOT: 'http4://converter:8080'
-      CLAMAV_ROOT: 'http4://clamav:8080'
-      DB_HOST: 'postgres'
-      AWS_LOCAL_HOST: 'localstack'
+      DOCS_QUEUE_NAME: "document-queue"
+      DOCS_QUEUE_DLQ_NAME: "document-queue-dlq"
+      CASE_QUEUE_NAME: "case-queue"
+      CASE_QUEUE_DLQ_NAME: "case-queue-dlq"
+      DOCS_TRUSTEDS3BUCKETNAME: "trusted-bucket"
+      DOCS_UNTRUSTEDS3BUCKETNAME: "untrusted-bucket"
+      HOCSCONVERTER_ROOT: "http4://converter:8080"
+      CLAMAV_ROOT: "http4://clamav:8080"
+      DB_HOST: "postgres"
+      AWS_LOCAL_HOST: "localstack"
     depends_on:
       postgres:
         condition: service_healthy
@@ -376,7 +375,7 @@ services:
 
   templates:
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 1m
       timeout: 30s
       retries: 3
@@ -387,9 +386,9 @@ services:
       - hocs-network
     environment:
       SERVER_PORT: 8080
-      HOCS_INFO_SERVICE: 'http://info:8080'
-      HOCS_AUDITSERVICE: 'http://casework:8080'
-      HOCS_SEARCH_SERVICE: 'http://documents:8080'
+      HOCS_INFO_SERVICE: "http://info:8080"
+      HOCS_AUDITSERVICE: "http://casework:8080"
+      HOCS_SEARCH_SERVICE: "http://documents:8080"
 
   case_creator:
     image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-latest}
@@ -398,27 +397,27 @@ services:
     networks:
       - hocs-network
     environment:
-      SPRING_PROFILES_ACTIVE: 'development, local'
+      SPRING_PROFILES_ACTIVE: "development, local"
       SERVER_PORT: 8080
-      AWS_LOCAL_HOST: 'localstack'
-      AWS_SQS_REGION: 'eu-west-2'
-      AWS_ACCOUNT_ID: '1234'
+      AWS_LOCAL_HOST: "localstack"
+      AWS_SQS_REGION: "eu-west-2"
+      AWS_ACCOUNT_ID: "1234"
       CASE_CREATOR_WORKFLOW_SERVICE: http://workflow:8080
       CASE_CREATOR_CASE_SERVICE: http://casework:8080
-      CASE_CREATOR_BASICAUTH: 'UNSET'
-      CASE_CREATOR_UKVI_COMPLAINT_USER: '22ca514d-c205-47a0-9e38-68daee4c1299'
-      CASE_CREATOR_UKVI_COMPLAINT_TEAM: '08e30ffc-2087-ff3a-b19b-343a88491347'
-      CASE_CREATOR_UKVI_COMPLAINT_GROUP: '/COMP_CCH_zqxmzQ6iEkTRw'
-      CASE_CREATOR_SQS_ACCESS_KEY: '1234'
-      CASE_CREATOR_SQS_SECRET_KEY: '1234'
-      CASE_CREATOR_UKVI_COMPLAINT_QUEUE_NAME: 'ukvi-complaint-queue'
-      CASE_CREATOR_UKVI_COMPLAINT_DL_QUEUE_NAME: 'ukvi-complaint-queue-dlq'
-      AUDIT_SNS_ACCESS_KEY: '1234'
-      AUDIT_SNS_SECRET_KEY: '1234'
+      CASE_CREATOR_BASICAUTH: "UNSET"
+      CASE_CREATOR_UKVI_COMPLAINT_USER: "22ca514d-c205-47a0-9e38-68daee4c1299"
+      CASE_CREATOR_UKVI_COMPLAINT_TEAM: "08e30ffc-2087-ff3a-b19b-343a88491347"
+      CASE_CREATOR_UKVI_COMPLAINT_GROUP: "/COMP_CCH_zqxmzQ6iEkTRw"
+      CASE_CREATOR_SQS_ACCESS_KEY: "1234"
+      CASE_CREATOR_SQS_SECRET_KEY: "1234"
+      CASE_CREATOR_UKVI_COMPLAINT_QUEUE_NAME: "ukvi-complaint-queue"
+      CASE_CREATOR_UKVI_COMPLAINT_DL_QUEUE_NAME: "ukvi-complaint-queue-dlq"
+      AUDIT_SNS_ACCESS_KEY: "1234"
+      AUDIT_SNS_SECRET_KEY: "1234"
       AUDIT_SNS_TOPIC_NAME: "hocs-audit-topic"
-      DOCUMENT_S3_ACCESS_KEY: '1234'
-      DOCUMENT_S3_SECRET_KEY: '1234'
-      DOCUMENT_S3_UNTRUSTED_BUCKET_NAME: 'untrusted-bucket'
+      DOCUMENT_S3_ACCESS_KEY: "1234"
+      DOCUMENT_S3_SECRET_KEY: "1234"
+      DOCUMENT_S3_UNTRUSTED_BUCKET_NAME: "untrusted-bucket"
     depends_on:
       aws_cli:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       CASEWORK_SERVICE: http://casework:8080
       INFO_SERVICE: http://info:8080
       DOCUMENT_SERVICE: http://documents:8080
-      ALLOWED_FILE_EXTENSIONS: 'txt,doc,docx'
+      ALLOWED_FILE_EXTENSIONS: "doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg"
       DOCUMENT_BULK_LIMIT: 40
       VALID_DAYS_RANGE: 180
       S3_BUCKET: "untrusted-bucket"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -192,19 +192,12 @@ services:
       - hocs-network
     environment:
       USE_CLIENTSIDE: "true"
-      WORKFLOW_SERVICE: http://workflow:8080
       CASEWORK_SERVICE: http://casework:8080
       INFO_SERVICE: http://info:8080
       DOCUMENT_SERVICE: http://documents:8080
       ALLOWED_FILE_EXTENSIONS: "doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg"
       PORT: 8080
-      S3_ENDPOINT: http://localstack:4572
-      DEFAULT_TIMEOUT_SECONDS: 300
-      COUNTDOWN_FOR_SECONDS: 60
-      MAX_UPLOAD_SIZE: 52428800
     depends_on:
-      workflow:
-        condition: service_healthy
       casework:
         condition: service_healthy
       info:
@@ -212,6 +205,8 @@ services:
       documents:
         condition: service_healthy
       localstack:
+        condition: service_healthy
+      aws_cli:
         condition: service_healthy
 
   casework:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -181,13 +181,13 @@ services:
 
   management-ui:
     healthcheck:
-      test: ["CMD", "wget", "-qo", "/dev/null", "http://localhost:8099/health"]
+      test: ["CMD", "wget", "-qo", "/dev/null", "http://localhost:8080/health"]
       interval: 10s
       timeout: 10s
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-management-ui:${MANAGEMENT_UI_TAG:-latest}
     ports:
-      - 8099:8099
+      - 8099:8080
     networks:
       - hocs-network
     environment:
@@ -197,7 +197,7 @@ services:
       INFO_SERVICE: http://info:8080
       DOCUMENT_SERVICE: http://documents:8080
       ALLOWED_FILE_EXTENSIONS: "doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg"
-      S3_BUCKET: "untrusted-bucket"
+      PORT: 8080
       S3_ENDPOINT: http://localstack:4572
       DEFAULT_TIMEOUT_SECONDS: 300
       COUNTDOWN_FOR_SECONDS: 60

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -179,6 +179,41 @@ services:
       localstack:
         condition: service_healthy
 
+  management-ui:
+    healthcheck:
+      test: ["CMD", "wget", "-qo", "/dev/null", "http://localhost:8099/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    image: quay.io/ukhomeofficedigital/hocs-management-ui:${MANAGEMENT_UI_TAG:-latest}
+    ports:
+      - 8099:8099
+    networks:
+      - hocs-network
+    environment:
+      USE_CLIENTSIDE: "true"
+      WORKFLOW_SERVICE: http://workflow:8080
+      CASEWORK_SERVICE: http://casework:8080
+      INFO_SERVICE: http://info:8080
+      DOCUMENT_SERVICE: http://documents:8080
+      ALLOWED_FILE_EXTENSIONS: "doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg"
+      S3_BUCKET: "untrusted-bucket"
+      S3_ENDPOINT: http://localstack:4572
+      DEFAULT_TIMEOUT_SECONDS: 300
+      COUNTDOWN_FOR_SECONDS: 60
+      MAX_UPLOAD_SIZE: 52428800
+    depends_on:
+      workflow:
+        condition: service_healthy
+      casework:
+        condition: service_healthy
+      info:
+        condition: service_healthy
+      documents:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
+
   casework:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]


### PR DESCRIPTION
One of the missing services is management-ui from the docker 
compose file. Too allow us to quickly set this up for developer 
usages this has been added to the docker compose file.

At present the docker-compose only passes through a very limited 
subset of allowed file extensions. This change brings this in line 
with what we accept within production at present.

We have a range of different changes that prettifier has changed. 
This commit applies all of these changes.