### PR TITLE
HOCS-3378 Adding camunda tools image to docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -459,15 +459,17 @@ services:
       start_period: 1m
       timeout: 30s
       retries: 3
-    image: quay.io/ukhomeofficedigital/hocs-camunda-tools:0.0.1
+    image: quay.io/ukhomeofficedigital/hocs-camunda-tools:0.0.2
     ports:
-      - 8089:8080
+      - 8093:8080
     networks:
       - hocs-network
     environment:
       DB_HOST: "postgres"
+      CAMUNDA_USERNAME: "admin"
+      CAMUNDA_PASSWORD: "admin"
     depends_on:
-      postgres:
+      workflow:
         condition: service_healthy
 
 networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -453,5 +453,22 @@ services:
       aws_cli:
         condition: service_healthy
 
+  camunda-tools:
+    healthcheck:
+      test: ["CMD", "java", "/app/scripts/HealthCheck.java", "http://localhost:8080/actuator/health", "||", "exit", "1"]
+      start_period: 1m
+      timeout: 30s
+      retries: 3
+    image: quay.io/ukhomeofficedigital/hocs-camunda-tools:0.0.1
+    ports:
+      - 8089:8080
+    networks:
+      - hocs-network
+    environment:
+      DB_HOST: "postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 networks:
   hocs-network:


### PR DESCRIPTION
Added new image containing the camunda toolset: cockpit, admin and tasklist. 

Image repo is here: https://quay.io/repository/ukhomeofficedigital/hocs-camunda-tools?tab=info
Git repo that the image is built from is here: https://github.com/UKHomeOffice/hocs-camunda-tools

Any feedback on the setup of the quay.io and git repos are welcome, there's likely some setting I've got wrong.

This is not supposed to be production ready in any sense. The ticket is simply to make the tools usable for us locally. More work would be required if we wanted to move this into other environments. I expect there will be infrequent changes to the git repo and therefore the quay.io repo so there is no automation in place at the moment to build and push an image. This could be done under a separate ticket if we get to a point where this is undergoing regular updates.