### PR TITLE
Spike/hocs 3374 run decs in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,8 @@ steps:
       event:
         - promote
         - cron
+      cron:
+        - afternoon
 
   - name: pull_load_elastic
     image: quay.io/ukhomeofficedigital/dind-awscli
@@ -47,6 +49,8 @@ steps:
       event:
         - promote
         - cron
+      cron:
+        - afternoon
 
   - name: compose_up
     image: docker/compose
@@ -62,6 +66,8 @@ steps:
       event:
         - promote
         - cron
+      cron:
+        - afternoon
 
   - name: integration_test
     image: busybox
@@ -73,6 +79,8 @@ steps:
       event:
         - promote
         - cron
+      cron:
+        - afternoon
 
   - name: compose_down
     image: docker/compose
@@ -85,6 +93,8 @@ steps:
       event:
         - promote
         - cron
+      cron:
+        - afternoon
 
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,14 @@ services:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
 
 steps:
+  - name: lint docker-compose
+    image: docker/compose
+    commands:
+      - docker-compose -f docker/docker-compose.yml config
+    when:
+      event:
+        - push
+
   - name: pull_data_migration
     image: quay.io/ukhomeofficedigital/dind-awscli
     environment:
@@ -63,5 +71,5 @@ environment:
 
 trigger:
   event:
-    - push
+    - promote
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,9 +7,6 @@ services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
 
-environment:
-  DOCKER_HOST: tcp://docker:2375
-
 steps:
   - name: pull_data_migration
     image: quay.io/ukhomeofficedigital/dind-awscli

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,9 @@ services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
 
+environment:
+  DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
+
 steps:
   - name: lint docker-compose
     image: docker/compose
@@ -15,6 +18,11 @@ steps:
     when:
       event:
         - push
+
+  - name: wait_for_docker
+    image: docker
+    commands:
+      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
 
   - name: pull_data_migration
     image: quay.io/ukhomeofficedigital/dind-awscli
@@ -27,6 +35,8 @@ steps:
     commands:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data
+    depends_on:
+      - wait_for_docker
     when:
       event:
         - promote
@@ -43,6 +53,8 @@ steps:
     commands:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
+    depends_on:
+      - wait_for_docker
     when:
       event:
         - promote
@@ -86,7 +98,4 @@ steps:
       event:
         - promote
         - cron
-
-environment:
-  DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,31 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
+  
+- name: pull data_migration
+  image: quay.io/ukhomeofficedigital/dind-awscli
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: migration_aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: migration_aws_secret_access_key
+    AWS_DEFAULT_REGION: eu-west-2
+  commands:
+    - $(aws ecr get-login --no-include-email)
+    - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data
+
+- name: pull load_elastic
+  image: quay.io/ukhomeofficedigital/dind-awscli
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: elastic_aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: elastic_aws_secret_access_key
+    AWS_DEFAULT_REGION: eu-west-2
+  commands:
+    - $(aws ecr get-login --no-include-email)
+    - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
+
 - name: lint docker-compose
   image: docker/compose
   commands:
@@ -21,7 +46,8 @@ steps:
   commands:
     - docker-compose -f docker/docker-compose.yml up
   depends_on:
-    - lint docker-compose
+    - pull data_migration
+    - pull load_elastic
 
 - name: docker-compose down
   image: docker/compose

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,10 +36,19 @@ steps:
     image: docker/compose
     commands:
       - cd docker
-      - docker-compose up clamav
+      - cp drone-docker-compose.override.yml docker-compose.override.yml
+      - docker-compose up -d
+      - ./scripts/composeDone.sh
     depends_on:
       - pull_data_migration
       - pull_load_elastic
+
+  - name: integration_test
+    image: busybox
+    commands:
+      - wget --spider --timeout=5 http://localhost:8080/health
+    depends_on:
+      - compose_up
 
   - name: compose_down
     image: docker/compose
@@ -47,7 +56,7 @@ steps:
       - cd docker
       - docker-compose down -v
     depends_on:
-      - compose_up
+      - integration_test
 
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,7 @@ steps:
     when:
       event:
         - promote
+        - cron
 
   - name: pull_load_elastic
     image: quay.io/ukhomeofficedigital/dind-awscli
@@ -45,6 +46,7 @@ steps:
     when:
       event:
         - promote
+        - cron
 
   - name: compose_up
     image: docker/compose
@@ -59,6 +61,7 @@ steps:
     when:
       event:
         - promote
+        - cron
 
   - name: integration_test
     image: busybox
@@ -69,6 +72,7 @@ steps:
     when:
       event:
         - promote
+        - cron
 
   - name: compose_down
     image: docker/compose
@@ -80,6 +84,7 @@ steps:
     when:
       event:
         - promote
+        - cron
 
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
@@ -88,4 +93,5 @@ trigger:
   event:
     - push
     - promote
+    - cron
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,4 @@
 ---
-
 kind: pipeline
 type: kubernetes
 name: lint
@@ -10,8 +9,21 @@ steps:
   commands:
     - docker-compose -f docker/docker-compose.yml config
 
+- name: docker-compose up
+  image: docker/compose
+  commands:
+    - docker-compose -f docker/docker-compose.yml up
+  depends_on:
+    - lint docker-compose
+
+- name: docker-compose down
+  image: docker/compose
+  commands:
+    - docker-compose -f docker/docker-compose.yml down
+  depends_on:
+    - docker-compose up
+
 trigger:
   event:
     - push
-
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,10 @@ steps:
     image: docker
     commands:
       - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
+    when:
+      event:
+        - promote
+        - cron
 
   - name: pull_data_migration
     image: quay.io/ukhomeofficedigital/dind-awscli

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,9 @@ steps:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
 
+environment:
+  DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
+
 trigger:
   event:
     - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: kubernetes
-name: lint
+name: hocs
 
 steps:
 - name: lint docker-compose

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,10 +5,7 @@ name: hocs
 
 services:
   - name: docker
-    image: quay.io/ukhomeofficedigital/dind
-    volumes:
-      - name: dockersock
-        path: /var/run
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
 
 environment:
   DOCKER_HOST: tcp://docker:2375
@@ -16,9 +13,6 @@ environment:
 steps:
   - name: wait_for_docker
     image: docker
-    volumes:
-      - name: dockersock
-        path: /var/run
     commands:
       - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,6 @@ steps:
     commands:
       - cd docker
       - cp drone-docker-compose.override.yml docker-compose.override.yml
-      - docker-compose pull
       - docker-compose up -d
       - ./scripts/composeDone.sh
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,21 @@ steps:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
 
+  - name: docker-compose up
+    image: docker/compose
+    commands:
+      - docker-compose -f docker/docker-compose.yml up postgres
+    depends_on:
+      - pull data_migration
+      - pull load_elastic
+
+  - name: docker-compose down
+    image: docker/compose
+    commands:
+      - docker-compose -f docker/docker-compose.yml down
+    depends_on:
+      - docker-compose up
+
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,20 +32,20 @@ steps:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
 
-  - name: docker-compose up
+  - name: compose_up
     image: docker/compose
     commands:
       - docker-compose -f docker/docker-compose.yml up postgres
     depends_on:
-      - pull data_migration
-      - pull load_elastic
+      - pull_data_migration
+      - pull_load_elastic
 
-  - name: docker-compose down
+  - name: compose_down
     image: docker/compose
     commands:
       - docker-compose -f docker/docker-compose.yml down
     depends_on:
-      - docker-compose up
+      - compose_up
 
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli

--- a/.drone.yml
+++ b/.drone.yml
@@ -53,6 +53,7 @@ steps:
     commands:
       - cd docker
       - cp drone-docker-compose.override.yml docker-compose.override.yml
+      - docker-compose pull
       - docker-compose up -d
       - ./scripts/composeDone.sh
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,8 @@ steps:
   - name: compose_up
     image: docker/compose
     commands:
-      - docker-compose -f docker/docker-compose.yml up clamav
+      - cd docker
+      - docker-compose up clamav
     depends_on:
       - pull_data_migration
       - pull_load_elastic
@@ -43,7 +44,8 @@ steps:
   - name: compose_down
     image: docker/compose
     commands:
-      - docker-compose -f docker/docker-compose.yml down
+      - cd docker
+      - docker-compose down -v
     depends_on:
       - compose_up
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,11 +11,6 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
-  - name: wait_for_docker
-    image: docker
-    commands:
-      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
-
   - name: pull_data_migration
     image: quay.io/ukhomeofficedigital/dind-awscli
     environment:
@@ -27,8 +22,6 @@ steps:
     commands:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data
-    depends_on:
-      - wait_for_docker
 
   - name: pull_load_elastic
     image: quay.io/ukhomeofficedigital/dind-awscli
@@ -41,8 +34,6 @@ steps:
     commands:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
-    depends_on:
-      - wait_for_docker
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,7 @@ steps:
   - name: compose_up
     image: docker/compose
     commands:
-      - docker-compose -f docker/docker-compose.yml up postgres
+      - docker-compose -f docker/docker-compose.yml up clamav
     depends_on:
       - pull_data_migration
       - pull_load_elastic

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,8 +31,6 @@ steps:
       event:
         - promote
         - cron
-      cron:
-        - afternoon
 
   - name: pull_load_elastic
     image: quay.io/ukhomeofficedigital/dind-awscli
@@ -49,8 +47,6 @@ steps:
       event:
         - promote
         - cron
-      cron:
-        - afternoon
 
   - name: compose_up
     image: docker/compose
@@ -66,9 +62,7 @@ steps:
       event:
         - promote
         - cron
-      cron:
-        - afternoon
-
+ 
   - name: integration_test
     image: busybox
     commands:
@@ -79,8 +73,6 @@ steps:
       event:
         - promote
         - cron
-      cron:
-        - afternoon
 
   - name: compose_down
     image: docker/compose
@@ -93,15 +85,7 @@ steps:
       event:
         - promote
         - cron
-      cron:
-        - afternoon
 
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
-
-trigger:
-  event:
-    - push
-    - promote
-    - cron
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,13 @@ kind: pipeline
 type: kubernetes
 name: hocs
 
+services:
+  - name: docker
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+
+environment:
+  DOCKER_HOST: tcp://docker:2375
+
 steps:
 - name: lint docker-compose
   image: docker/compose

--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,9 @@ steps:
     commands:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data
+    when:
+      event:
+        - promote
 
   - name: pull_load_elastic
     image: quay.io/ukhomeofficedigital/dind-awscli
@@ -39,6 +42,9 @@ steps:
     commands:
       - $(aws ecr get-login --no-include-email)
       - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
+    when:
+      event:
+        - promote
 
   - name: compose_up
     image: docker/compose
@@ -50,6 +56,9 @@ steps:
     depends_on:
       - pull_data_migration
       - pull_load_elastic
+    when:
+      event:
+        - promote
 
   - name: integration_test
     image: busybox
@@ -57,6 +66,9 @@ steps:
       - wget --spider --timeout=5 http://localhost:8080/health
     depends_on:
       - compose_up
+    when:
+      event:
+        - promote
 
   - name: compose_down
     image: docker/compose
@@ -65,11 +77,15 @@ steps:
       - docker-compose down -v
     depends_on:
       - integration_test
+    when:
+      event:
+        - promote
 
 environment:
   DOCKER_HOST: tcp://docker:2375 # needed by dind-awscli
 
 trigger:
   event:
+    - push
     - promote
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,56 +5,50 @@ name: hocs
 
 services:
   - name: docker
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+    image: quay.io/ukhomeofficedigital/dind
+    volumes:
+      - name: dockersock
+        path: /var/run
 
 environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
-  
-- name: pull data_migration
-  image: quay.io/ukhomeofficedigital/dind-awscli
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: migration_aws_access_key_id
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: migration_aws_secret_access_key
-    AWS_DEFAULT_REGION: eu-west-2
-  commands:
-    - $(aws ecr get-login --no-include-email)
-    - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data
+  - name: wait_for_docker
+    image: docker
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
 
-- name: pull load_elastic
-  image: quay.io/ukhomeofficedigital/dind-awscli
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: elastic_aws_access_key_id
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: elastic_aws_secret_access_key
-    AWS_DEFAULT_REGION: eu-west-2
-  commands:
-    - $(aws ecr get-login --no-include-email)
-    - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
+  - name: pull_data_migration
+    image: quay.io/ukhomeofficedigital/dind-awscli
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: migration_aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: migration_aws_secret_access_key
+      AWS_DEFAULT_REGION: eu-west-2
+    commands:
+      - $(aws ecr get-login --no-include-email)
+      - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data
+    depends_on:
+      - wait_for_docker
 
-- name: lint docker-compose
-  image: docker/compose
-  commands:
-    - docker-compose -f docker/docker-compose.yml config
-
-- name: docker-compose up
-  image: docker/compose
-  commands:
-    - docker-compose -f docker/docker-compose.yml up
-  depends_on:
-    - pull data_migration
-    - pull load_elastic
-
-- name: docker-compose down
-  image: docker/compose
-  commands:
-    - docker-compose -f docker/docker-compose.yml down
-  depends_on:
-    - docker-compose up
+  - name: pull_load_elastic
+    image: quay.io/ukhomeofficedigital/dind-awscli
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: elastic_aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: elastic_aws_secret_access_key
+      AWS_DEFAULT_REGION: eu-west-2
+    commands:
+      - $(aws ecr get-login --no-include-email)
+      - docker pull 340268328991.dkr.ecr.eu-west-2.amazonaws.com/hocs/hocs-data-elastic
+    depends_on:
+      - wait_for_docker
 
 trigger:
   event:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /docker/keycloak/hsperfdata_jboss
 .env
+docker-compose.override.yml

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,14 @@
+#FRONTEND_TAG=branch-feature_HOCS-3547-overdue-rework
+#MANAGEMENT_UI_TAG=branch-HOCS-3449-Add-management-of-exgratia-business-reps
+#CASE_CREATOR_TAG=branch-feature_HOCS-3522-rd-startCasesAtCorrectStage
+#CASEWORK_TAG=branch-feature_HOCS-3547-overdue-rework
+#DOCS_TAG=branch-fix_HOCS-3508-document-conversion-failure
+#WORKFLOW_TAG=branch-feature_HOCS-3449-Swapping-to-exgratia-bus-contributions
+#INFO_TAG=branch-HOCS-3449-adding-delete-to-entity-table
+#TEMPLATES_TAG=branch-feature_HOCS-3189-Upgrading-to-gradle-7.1-and-spring-2.5.1
+#SEARCH_TAG=branch-fix_HOCS-3496-delete-topic
+#DOCS_CONVERTER_TAG=branch-fix_HOCS-3508-document-conversion-failure
+#AUDIT_TAG=branch-fix_HOCS-3682-empty-extract
+#HOCS_DATA_TAG=branch-feature_HOCS-3449-exgratia-business-contributions
+#HOCS_DATA_ELASTIC_REPO=hocs-data-wcs-elastic
+#HOCS_DATA_REPO=hocs-data-wcs

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U root"]
     restart: always
     ports:
-      - 5432:5432
+      - "5432:5432"
     networks:
       - hocs-network
     environment:
@@ -23,7 +23,7 @@ services:
     image: mockserver/mockserver:mockserver-5.11.1
     command: -logLevel INFO -serverPort 8080
     ports:
-      - 8086:8080
+      - "8086:8080"
     networks:
       - hocs-network
     environment:
@@ -39,8 +39,8 @@ services:
     image: jboss/keycloak:5.0.0
     restart: always
     ports:
-      - 9990:9990
-      - 9081:8080
+      - "9990:9990"
+      - "9081:8080"
     networks:
       - hocs-network
     environment:
@@ -59,12 +59,12 @@ services:
       retries: 3
     image: localstack/localstack:0.9.5
     ports:
-      - 9000:8080
-      - 4572:4572
-      - 4576:4576
-      - 4575:4575
-      - 4571:4571
-      - 4578:4578
+      - "9000:8080"
+      - "4572:4572"
+      - "4576:4576"
+      - "4575:4575"
+      - "4571:4571"
+      - "4578:4578"
     networks:
       - hocs-network
     environment:
@@ -153,7 +153,7 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-latest}
     ports:
-      - 8080:8080
+      - "8080:8080"
     networks:
       - hocs-network
     environment:
@@ -179,7 +179,7 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-management-ui:${MANAGEMENT_UI_TAG:-latest}
     ports:
-      - 8099:8080
+      - "8099:8080"
     networks:
       - hocs-network
     environment:
@@ -205,8 +205,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG:-latest}
     ports:
-      - 8082:8080
-      - 7082:8000
+      - "8082:8080"
+      - "7082:8000"
     networks:
       - hocs-network
     environment:
@@ -236,8 +236,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG:-latest}
     ports:
-      - 8091:8080
-      - 7091:8000
+      - "8091:8080"
+      - "7091:8000"
     networks:
       - hocs-network
     environment:
@@ -267,8 +267,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG:-latest}
     ports:
-      - 8087:8080
-      - 7087:8000
+      - "8087:8080"
+      - "7087:8000"
     networks:
       - hocs-network
     environment:
@@ -294,8 +294,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG:-latest}
     ports:
-      - 8088:8080
-      - 7088:8000
+      - "8088:8080"
+      - "7088:8000"
     networks:
       - hocs-network
     environment:
@@ -329,8 +329,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG:-latest}
     ports:
-      - 8085:8080
-      - 7085:8000
+      - "8085:8080"
+      - "7085:8000"
     networks:
       - hocs-network
     environment:
@@ -367,8 +367,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-notify:${NOTIFY_TAG:-latest}
     ports:
-      - 8089:8080
-      - 7089:8000
+      - "8089:8080"
+      - "7089:8000"
     networks:
       - hocs-network
     environment:
@@ -394,8 +394,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-latest}
     ports:
-      - 8084:8080
-      - 7084:8000
+      - "8084:8080"
+      - "7084:8000"
     networks:
       - hocs-network
     environment:
@@ -411,8 +411,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG:-latest}
     ports:
-      - 8083:8080
-      - 7083:8000
+      - "8083:8080"
+      - "7083:8000"
     networks:
       - hocs-network
     environment:
@@ -446,8 +446,8 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG:-latest}
     ports:
-      - 8090:8080
-      - 7090:8000
+      - "8090:8080"
+      - "7090:8000"
     networks:
       - hocs-network
     environment:
@@ -460,8 +460,8 @@ services:
   case_creator:
     image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG:-latest}
     ports:
-      - 8092:8080
-      - 7092:8000
+      - "8092:8080"
+      - "7092:8000"
     networks:
       - hocs-network
     environment:
@@ -499,7 +499,7 @@ services:
       retries: 3
     image: quay.io/ukhomeofficedigital/hocs-camunda-tools:0.0.3
     ports:
-      - 8093:8080
+      - "8093:8080"
     networks:
       - hocs-network
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -168,15 +168,7 @@ services:
       S3_BUCKET: "untrusted-bucket"
       S3_ENDPOINT: http://localstack:4572
     depends_on:
-      workflow:
-        condition: service_healthy
-      casework:
-        condition: service_healthy
       info:
-        condition: service_healthy
-      documents:
-        condition: service_healthy
-      localstack:
         condition: service_healthy
 
   management-ui:
@@ -198,11 +190,7 @@ services:
       ALLOWED_FILE_EXTENSIONS: "doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg"
       PORT: 8080
     depends_on:
-      casework:
-        condition: service_healthy
       info:
-        condition: service_healthy
-      documents:
         condition: service_healthy
       localstack:
         condition: service_healthy
@@ -370,8 +358,6 @@ services:
         condition: service_started
       keycloak:
         condition: service_started
-      notify:
-        condition: service_started
 
   notify:
     healthcheck:
@@ -414,6 +400,7 @@ services:
       - hocs-network
     environment:
       JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000"
+      SPRING_PROFILES_ACTIVE: "development, local"
       SERVER_PORT: 8080
 
   documents:
@@ -447,8 +434,6 @@ services:
       postgres:
         condition: service_healthy
       localstack:
-        condition: service_healthy
-      converter:
         condition: service_healthy
       aws_cli:
         condition: service_started

--- a/docker/drone-docker-compose.override.yml
+++ b/docker/drone-docker-compose.override.yml
@@ -1,0 +1,23 @@
+version: "2.4"
+
+services:
+  management-ui:
+    healthcheck:
+      test: exit 0
+    image: busybox
+    command: [ "echo", "management-ui override" ]
+
+  case_creator:
+    environment:
+      CASE_CREATOR_CASE_SERVICE: http://docker.for.mac.localhost:8082
+    healthcheck:
+      test: exit 0
+    image: busybox
+    command: [ "echo", "case_creator override" ]
+
+  camunda-tools:
+    healthcheck:
+      test: exit 0
+    image: busybox
+    command: [ "echo", "camunda-tools override" ]
+

--- a/docker/scripts/composeDone.sh
+++ b/docker/scripts/composeDone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 while ! wget --spider --timeout=5 http://localhost:8080/health 
 do

--- a/docker/scripts/composeDone.sh
+++ b/docker/scripts/composeDone.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while ! wget --spider --timeout=5 http://localhost:8080/health 
+do
+  sleep 10
+done
+

--- a/docker/scripts/infrastructure.sh
+++ b/docker/scripts/infrastructure.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Pulling latest and setting up infrastructure services"
-docker-compose up -d postgres localstack clamav aws_cli converter keycloak
+docker-compose up -d postgres localstack clamav aws_cli converter keycloak load_elastic data_migration

--- a/docker/scripts/services.sh
+++ b/docker/scripts/services.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Pulling latest and setting up services"
-docker-compose up -d documents audit workflow casework info search templates
+docker-compose up -d documents audit workflow casework info search templates frontend refresh_members


### PR DESCRIPTION
This PR adds steps to pull and start the latest decs system.

It starts up, runs a simple test (as a place holder) and then stops.

A cron job has also been set up to run at midnight.

Also a few general improvements to the docker-compose