### PR TITLE
HOCS-4116 Change converter healthcheck to wget

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -407,7 +407,7 @@ services:
     
   converter:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "wget", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG:-latest}
     ports:
       - 8084:8080


### PR DESCRIPTION
We changed the base hocs-libreoffice image to alpine which does not have
curl, so this updates the healthcheck command to use wget instead