### PR TITLE
HOCS-4532: peg keycloak version to production

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
       start_period: 1m
-    image: jboss/keycloak:5.0.0
+    image: jboss/keycloak:11.0.2
     restart: always
     ports:
       - 9990:9990
@@ -529,4 +529,3 @@ services:
 
 networks:
   hocs-network:
-  


### PR DESCRIPTION
Current production version of Keycloak is running on 11.0.2. This change
pegs the version used within the docker-compose file to the version in
production.