### PR TITLE
HOCS-5006: remove version of ES Domain

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,7 +105,7 @@ services:
         aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name ukvi-complaint-queue-dlq
         aws --endpoint-url=http://localstack:4572 s3 mb s3://untrusted-bucket
         aws --endpoint-url=http://localstack:4572 s3 mb s3://trusted-bucket
-        aws --endpoint-url=http://localstack:4578 es create-elasticsearch-domain --domain-name decs --elasticsearch-version 6.7
+        aws --endpoint-url=http://localstack:4578 es create-elasticsearch-domain --domain-name decs
         sleep 8h
     environment:
       AWS_ACCESS_KEY_ID: UNSET


### PR DESCRIPTION
As the Elasticsearch mapping is now inline with 7.x. This change moves
away from creating a Elasticsearch domain of version 6.7. The version of
 LocalStack we use defaults to `7.10`.