### PR TITLE
Add to deployment documentation

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,4 +1,4 @@
-kubectl command for fetching current versions on an environment:
+kubectl command for fetching current image versions on an environment:
 
 ```
 kubectl get deployment -n <ENVIRONMENT> -o custom-columns=:"metadata.labels.version,SERVICE:metadata.name"

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,3 +1,9 @@
+kubectl command for fetching current versions on an environment:
+
+```
+kubectl get deployment -n <ENVIRONMENT> -o custom-columns=:"metadata.labels.version,SERVICE:metadata.name"
+```
+
 Bash functions for prod deployments:
 
 ```


### PR DESCRIPTION
Adds example kubectl command for fetching current versions
deployed to an envionment. Useful for checking environment state
before and after deployments