### PR TITLE
:see_no_evil: Add to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /docker/keycloak/hsperfdata_jboss
 .env
 .idea
+
+/documentation/_site
+/documentation/node_modules


### PR DESCRIPTION
Add the generated site and the node_modules for the documentation to the
 gitignore.